### PR TITLE
Remove unused category and priority fields from UI

### DIFF
--- a/src/features/admin/api/stampAnswerApi.ts
+++ b/src/features/admin/api/stampAnswerApi.ts
@@ -1,98 +1,65 @@
-import { apiClient } from "../../../shared/ui/services/apiClient";
-import type {
-  StampAnswer,
-  CreateStampAnswerRequest,
-  UpdateStampAnswerRequest,
-} from "../types/stampAnswer.types";
+import { apiClient } from '../../../shared/ui/services/apiClient';
+import type { StampAnswer, CreateStampAnswerRequest, UpdateStampAnswerRequest } from '../types/stampAnswer.types';
 
-const STAMP_ANSWERS_BASE_URL = "/api/v1/stamp-answers";
+const STAMP_ANSWERS_BASE_URL = '/api/v1/stamp-answers';
 
 export const stampAnswerApi = {
-  /**
-   * Get all stamp answers
-   */
-  getAll: async (activeOnly = false): Promise<StampAnswer[]> => {
-    const response = await apiClient.get<StampAnswer[]>(
-      STAMP_ANSWERS_BASE_URL,
-      {
-        params: { activeOnly },
-      },
-    );
-    return response.data;
-  },
+    /**
+     * Get all stamp answers
+     */
+    getAll: async (activeOnly = false): Promise<StampAnswer[]> => {
+        const response = await apiClient.get<StampAnswer[]>(STAMP_ANSWERS_BASE_URL, {
+            params: { activeOnly },
+        });
+        return response.data;
+    },
 
-  /**
-   * Get stamp answer by ID
-   */
-  getById: async (id: number): Promise<StampAnswer> => {
-    const response = await apiClient.get<StampAnswer>(
-      `${STAMP_ANSWERS_BASE_URL}/${id}`,
-    );
-    return response.data;
-  },
+    /**
+     * Get stamp answer by ID
+     */
+    getById: async (id: number): Promise<StampAnswer> => {
+        const response = await apiClient.get<StampAnswer>(`${STAMP_ANSWERS_BASE_URL}/${id}`);
+        return response.data;
+    },
 
-  /**
-   * Search stamp answers
-   */
-  search: async (searchTerm: string): Promise<StampAnswer[]> => {
-    const response = await apiClient.get<StampAnswer[]>(
-      `${STAMP_ANSWERS_BASE_URL}/search`,
-      {
-        params: { q: searchTerm },
-      },
-    );
-    return response.data;
-  },
+    /**
+     * Search stamp answers
+     */
+    search: async (searchTerm: string): Promise<StampAnswer[]> => {
+        const response = await apiClient.get<StampAnswer[]>(`${STAMP_ANSWERS_BASE_URL}/search`, {
+            params: { q: searchTerm },
+        });
+        return response.data;
+    },
 
-  /**
-   * Create new stamp answer
-   */
-  create: async (request: CreateStampAnswerRequest): Promise<StampAnswer> => {
-    const response = await apiClient.post<StampAnswer>(
-      STAMP_ANSWERS_BASE_URL,
-      request,
-    );
-    return response.data;
-  },
+    /**
+     * Create new stamp answer
+     */
+    create: async (request: CreateStampAnswerRequest): Promise<StampAnswer> => {
+        const response = await apiClient.post<StampAnswer>(STAMP_ANSWERS_BASE_URL, request);
+        return response.data;
+    },
 
-  /**
-   * Update stamp answer
-   */
-  update: async (
-    id: number,
-    request: UpdateStampAnswerRequest,
-  ): Promise<StampAnswer> => {
-    const response = await apiClient.put<StampAnswer>(
-      `${STAMP_ANSWERS_BASE_URL}/${id}`,
-      request,
-    );
-    return response.data;
-  },
+    /**
+     * Update stamp answer
+     */
+    update: async (id: number, request: UpdateStampAnswerRequest): Promise<StampAnswer> => {
+        const response = await apiClient.put<StampAnswer>(`${STAMP_ANSWERS_BASE_URL}/${id}`, request);
+        return response.data;
+    },
 
-  /**
-   * Delete stamp answer
-   */
-  delete: async (id: number): Promise<void> => {
-    await apiClient.delete(`${STAMP_ANSWERS_BASE_URL}/${id}`);
-  },
+    /**
+     * Delete stamp answer
+     */
+    delete: async (id: number): Promise<void> => {
+        await apiClient.delete(`${STAMP_ANSWERS_BASE_URL}/${id}`);
+    },
 
-  /**
-   * Get most used stamp answers
-   */
-  getMostUsed: async (): Promise<StampAnswer[]> => {
-    const response = await apiClient.get<StampAnswer[]>(
-      `${STAMP_ANSWERS_BASE_URL}/most-used`,
-    );
-    return response.data;
-  },
-
-  /**
-   * Get stamp answers by category
-   */
-  getByCategory: async (category: string): Promise<StampAnswer[]> => {
-    const response = await apiClient.get<StampAnswer[]>(
-      `${STAMP_ANSWERS_BASE_URL}/category/${category}`,
-    );
-    return response.data;
-  },
+    /**
+     * Get most used stamp answers
+     */
+    getMostUsed: async (): Promise<StampAnswer[]> => {
+        const response = await apiClient.get<StampAnswer[]>(`${STAMP_ANSWERS_BASE_URL}/most-used`);
+        return response.data;
+    },
 };

--- a/src/features/admin/components/StampAnswerDialog.tsx
+++ b/src/features/admin/components/StampAnswerDialog.tsx
@@ -1,221 +1,176 @@
-import { useState, useEffect } from "react";
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  TextField,
-  Box,
-  Alert,
-} from "@mui/material";
-import { stampAnswerApi } from "../api/stampAnswerApi";
-import type {
-  StampAnswer,
-  CreateStampAnswerRequest,
-  UpdateStampAnswerRequest,
-} from "../types/stampAnswer.types";
+import { useState, useEffect } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Box, Alert } from '@mui/material';
+import { stampAnswerApi } from '../api/stampAnswerApi';
+import type { StampAnswer, CreateStampAnswerRequest, UpdateStampAnswerRequest } from '../types/stampAnswer.types';
 
 interface StampAnswerDialogProps {
-  open: boolean;
-  answer: StampAnswer | null;
-  onClose: (reload?: boolean) => void;
+    open: boolean;
+    answer: StampAnswer | null;
+    onClose: (reload?: boolean) => void;
 }
 
-export default function StampAnswerDialog({
-  open,
-  answer,
-  onClose,
-}: StampAnswerDialogProps) {
-  const [formData, setFormData] = useState({
-    question: "",
-    answer: "",
-    keywords: "",
-    category: "",
-    priority: 0,
-  });
-  const [errors, setErrors] = useState<{ [key: string]: string }>({});
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+export default function StampAnswerDialog({ open, answer, onClose }: StampAnswerDialogProps) {
+    const [formData, setFormData] = useState({
+        question: '',
+        answer: '',
+        keywords: '',
+    });
+    const [errors, setErrors] = useState<{ [key: string]: string }>({});
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (answer) {
-      setFormData({
-        question: answer.question,
-        answer: answer.answer,
-        keywords: answer.keywords || "",
-        category: answer.category || "",
-        priority: answer.priority,
-      });
-    } else {
-      setFormData({
-        question: "",
-        answer: "",
-        keywords: "",
-        category: "",
-        priority: 0,
-      });
-    }
-    setErrors({});
-    setError(null);
-  }, [answer, open]);
+    useEffect(() => {
+        if (answer) {
+            setFormData({
+                question: answer.question,
+                answer: answer.answer,
+                keywords: answer.keywords || '',
+            });
+        } else {
+            setFormData({
+                question: '',
+                answer: '',
+                keywords: '',
+            });
+        }
+        setErrors({});
+        setError(null);
+    }, [answer, open]);
 
-  const validateForm = (): boolean => {
-    const newErrors: { [key: string]: string } = {};
+    const validateForm = (): boolean => {
+        const newErrors: { [key: string]: string } = {};
 
-    if (!formData.question.trim()) {
-      newErrors.question = "Küsimus on kohustuslik";
-    }
+        if (!formData.question.trim()) {
+            newErrors.question = 'Küsimus on kohustuslik';
+        }
 
-    if (!formData.answer.trim()) {
-      newErrors.answer = "Vastus on kohustuslik";
-    }
+        if (!formData.answer.trim()) {
+            newErrors.answer = 'Vastus on kohustuslik';
+        }
 
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleChange =
-    (field: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      setFormData((prev) => ({
-        ...prev,
-        [field]: field === "priority" ? Number(value) : value,
-      }));
-      // Clear error for this field
-      if (errors[field]) {
-        setErrors((prev) => ({ ...prev, [field]: "" }));
-      }
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
     };
 
-  const handleSave = async () => {
-    if (!validateForm()) {
-      return;
-    }
+    const handleChange = (field: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
+        setFormData((prev) => ({
+            ...prev,
+            [field]: event.target.value,
+        }));
+        // Clear error for this field
+        if (errors[field]) {
+            setErrors((prev) => ({ ...prev, [field]: '' }));
+        }
+    };
 
-    setSaving(true);
-    setError(null);
+    const handleSave = async () => {
+        if (!validateForm()) {
+            return;
+        }
 
-    try {
-      if (answer) {
-        // Update existing answer
-        const updateRequest: UpdateStampAnswerRequest = {
-          question: formData.question,
-          answer: formData.answer,
-          keywords: formData.keywords || undefined,
-          category: formData.category || undefined,
-          priority: formData.priority,
-        };
-        await stampAnswerApi.update(answer.id, updateRequest);
-      } else {
-        // Create new answer
-        const createRequest: CreateStampAnswerRequest = {
-          question: formData.question,
-          answer: formData.answer,
-          keywords: formData.keywords || undefined,
-          category: formData.category || undefined,
-          priority: formData.priority,
-        };
-        await stampAnswerApi.create(createRequest);
-      }
-      onClose(true); // Close and reload
-    } catch (err) {
-      setError("Viga valmisvastuse salvestamisel");
-      console.error("Error saving stamp answer:", err);
-    } finally {
-      setSaving(false);
-    }
-  };
+        setSaving(true);
+        setError(null);
 
-  const handleClose = () => {
-    if (!saving) {
-      onClose(false);
-    }
-  };
+        try {
+            if (answer) {
+                // Update existing answer
+                const updateRequest: UpdateStampAnswerRequest = {
+                    question: formData.question,
+                    answer: formData.answer,
+                    keywords: formData.keywords || undefined,
+                };
+                await stampAnswerApi.update(answer.id, updateRequest);
+            } else {
+                // Create new answer
+                const createRequest: CreateStampAnswerRequest = {
+                    question: formData.question,
+                    answer: formData.answer,
+                    keywords: formData.keywords || undefined,
+                };
+                await stampAnswerApi.create(createRequest);
+            }
+            onClose(true); // Close and reload
+        } catch (err) {
+            setError('Viga valmisvastuse salvestamisel');
+            console.error('Error saving stamp answer:', err);
+        } finally {
+            setSaving(false);
+        }
+    };
 
-  return (
-    <Dialog
-      open={open}
-      onClose={handleClose}
-      maxWidth="md"
-      fullWidth
-      PaperProps={{ sx: { borderRadius: 2, overflow: "hidden" } }}
-    >
-      <DialogTitle
-        sx={(theme) => ({
-          bgcolor: theme.palette.primary.main,
-          color: "#fff",
-          py: 2,
-          px: 3,
-          // corners are clipped by Paper's overflow:hidden
-        })}
-      >
-        {answer ? "Muuda valmisvastust" : "Lisa uus valmisvastus"}
-      </DialogTitle>
-      <DialogContent sx={{ pt: 4, pb: 2 }}>
-        {error && (
-          <Alert severity="error" sx={{ mb: 2 }}>
-            {error}
-          </Alert>
-        )}
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 2 }}>
-          <TextField
-            label="Küsimus"
-            value={formData.question}
-            onChange={handleChange("question")}
-            error={!!errors.question}
-            helperText={errors.question}
+    const handleClose = () => {
+        if (!saving) {
+            onClose(false);
+        }
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            maxWidth="md"
             fullWidth
-            required
-            multiline
-            rows={2}
-          />
+            PaperProps={{ sx: { borderRadius: 2, overflow: 'hidden' } }}
+        >
+            <DialogTitle
+                sx={(theme) => ({
+                    bgcolor: theme.palette.primary.main,
+                    color: '#fff',
+                    py: 2,
+                    px: 3,
+                    // corners are clipped by Paper's overflow:hidden
+                })}
+            >
+                {answer ? 'Muuda valmisvastust' : 'Lisa uus valmisvastus'}
+            </DialogTitle>
+            <DialogContent sx={{ pt: 4, pb: 2 }}>
+                {error && (
+                    <Alert severity="error" sx={{ mb: 2 }}>
+                        {error}
+                    </Alert>
+                )}
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
+                    <TextField
+                        label="Küsimus"
+                        value={formData.question}
+                        onChange={handleChange('question')}
+                        error={!!errors.question}
+                        helperText={errors.question}
+                        fullWidth
+                        required
+                        multiline
+                        rows={2}
+                    />
 
-          <TextField
-            label="Vastus"
-            value={formData.answer}
-            onChange={handleChange("answer")}
-            error={!!errors.answer}
-            helperText={errors.answer}
-            fullWidth
-            required
-            multiline
-            rows={4}
-          />
+                    <TextField
+                        label="Vastus"
+                        value={formData.answer}
+                        onChange={handleChange('answer')}
+                        error={!!errors.answer}
+                        helperText={errors.answer}
+                        fullWidth
+                        required
+                        multiline
+                        rows={4}
+                    />
 
-          <TextField
-            label="Märksõnad"
-            value={formData.keywords}
-            onChange={handleChange("keywords")}
-            fullWidth
-            helperText="Komaga eraldatud märksõnad otsingu jaoks"
-          />
-
-          <TextField
-            label="Kategooria"
-            value={formData.category}
-            onChange={handleChange("category")}
-            fullWidth
-          />
-
-          <TextField
-            label="Prioriteet"
-            type="number"
-            value={formData.priority}
-            onChange={handleChange("priority")}
-            fullWidth
-            helperText="Kõrgem number = kõrgem prioriteet"
-          />
-        </Box>
-      </DialogContent>
-      <DialogActions sx={{ px: 3, pt: 3, pb: 2 }}>
-        <Button onClick={handleClose} disabled={saving}>
-          Tühista
-        </Button>
-        <Button onClick={handleSave} variant="contained" disabled={saving}>
-          {saving ? "Salvestamine..." : "Salvesta"}
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
+                    <TextField
+                        label="Märksõnad"
+                        value={formData.keywords}
+                        onChange={handleChange('keywords')}
+                        fullWidth
+                        helperText="Komaga eraldatud märksõnad otsingu jaoks"
+                    />
+                </Box>
+            </DialogContent>
+            <DialogActions sx={{ px: 3, pt: 3, pb: 2 }}>
+                <Button onClick={handleClose} disabled={saving}>
+                    Tühista
+                </Button>
+                <Button onClick={handleSave} variant="contained" disabled={saving}>
+                    {saving ? 'Salvestamine...' : 'Salvesta'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
 }

--- a/src/features/admin/pages/StampAnswersPage.tsx
+++ b/src/features/admin/pages/StampAnswersPage.tsx
@@ -1,397 +1,332 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 import {
-  Box,
-  Button,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TextField,
-  Typography,
-  IconButton,
-  MenuItem,
-  Select,
-  FormControl,
-  InputLabel,
-  Chip,
-  CircularProgress,
-  Alert,
-} from "@mui/material";
-import type { SelectChangeEvent } from "@mui/material";
-import {
-  Add as AddIcon,
-  Edit as EditIcon,
-  Search as SearchIcon,
-} from "@mui/icons-material";
-import { stampAnswerApi } from "../api/stampAnswerApi";
-import type { StampAnswer } from "../types/stampAnswer.types";
-import StampAnswerDialog from "../components/StampAnswerDialog";
-import DeleteConfirmationDialog from "../components/DeleteConfirmationDialog";
+    Box,
+    Button,
+    Paper,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TextField,
+    Typography,
+    IconButton,
+    MenuItem,
+    Select,
+    FormControl,
+    InputLabel,
+    Chip,
+    CircularProgress,
+    Alert,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
+import { Add as AddIcon, Edit as EditIcon, Search as SearchIcon } from '@mui/icons-material';
+import { stampAnswerApi } from '../api/stampAnswerApi';
+import type { StampAnswer } from '../types/stampAnswer.types';
+import StampAnswerDialog from '../components/StampAnswerDialog';
+import DeleteConfirmationDialog from '../components/DeleteConfirmationDialog';
 
 export default function StampAnswersPage() {
-  const [stampAnswers, setStampAnswers] = useState<StampAnswer[]>([]);
-  const [filteredAnswers, setFilteredAnswers] = useState<StampAnswer[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState("");
-  const [filterActive, setFilterActive] = useState<string>("all");
-  const [sortBy, setSortBy] = useState<string>("recent");
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [selectedAnswer, setSelectedAnswer] = useState<StampAnswer | null>(
-    null,
-  );
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [deleteTarget, setDeleteTarget] = useState<StampAnswer | null>(null);
+    const [stampAnswers, setStampAnswers] = useState<StampAnswer[]>([]);
+    const [filteredAnswers, setFilteredAnswers] = useState<StampAnswer[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [filterActive, setFilterActive] = useState<string>('all');
+    const [sortBy, setSortBy] = useState<string>('recent');
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [selectedAnswer, setSelectedAnswer] = useState<StampAnswer | null>(null);
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [deleteTarget, setDeleteTarget] = useState<StampAnswer | null>(null);
 
-  useEffect(() => {
-    loadStampAnswers();
-  }, []);
+    useEffect(() => {
+        loadStampAnswers();
+    }, []);
 
-  useEffect(() => {
-    applyFiltersAndSort();
-  }, [stampAnswers, searchTerm, filterActive, sortBy]);
+    useEffect(() => {
+        applyFiltersAndSort();
+    }, [stampAnswers, searchTerm, filterActive, sortBy]);
 
-  const loadStampAnswers = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const data = await stampAnswerApi.getAll();
-      setStampAnswers(data);
-    } catch (err) {
-      setError("Viga valmisvastuste laadimisel");
-      console.error("Error loading stamp answers:", err);
-    } finally {
-      setLoading(false);
-    }
-  };
+    const loadStampAnswers = async () => {
+        try {
+            setLoading(true);
+            setError(null);
+            const data = await stampAnswerApi.getAll();
+            setStampAnswers(data);
+        } catch (err) {
+            setError('Viga valmisvastuste laadimisel');
+            console.error('Error loading stamp answers:', err);
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  const applyFiltersAndSort = () => {
-    let filtered = [...stampAnswers];
+    const applyFiltersAndSort = () => {
+        let filtered = [...stampAnswers];
 
-    // Apply search filter
-    if (searchTerm) {
-      const lowerSearch = searchTerm.toLowerCase();
-      filtered = filtered.filter(
-        (answer) =>
-          answer.question.toLowerCase().includes(lowerSearch) ||
-          answer.answer.toLowerCase().includes(lowerSearch) ||
-          answer.keywords?.toLowerCase().includes(lowerSearch),
-      );
-    }
+        // Apply search filter
+        if (searchTerm) {
+            const lowerSearch = searchTerm.toLowerCase();
+            filtered = filtered.filter(
+                (answer) =>
+                    answer.question.toLowerCase().includes(lowerSearch) ||
+                    answer.answer.toLowerCase().includes(lowerSearch) ||
+                    answer.keywords?.toLowerCase().includes(lowerSearch),
+            );
+        }
 
-    // Apply active filter
-    if (filterActive === "active") {
-      filtered = filtered.filter((answer) => answer.isActive);
-    } else if (filterActive === "inactive") {
-      filtered = filtered.filter((answer) => !answer.isActive);
-    }
+        // Apply active filter
+        if (filterActive === 'active') {
+            filtered = filtered.filter((answer) => answer.isActive);
+        } else if (filterActive === 'inactive') {
+            filtered = filtered.filter((answer) => !answer.isActive);
+        }
 
-    // Apply sorting
-    switch (sortBy) {
-      case "recent":
-        filtered.sort(
-          (a, b) =>
-            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        // Apply sorting
+        switch (sortBy) {
+            case 'recent':
+                filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+                break;
+            case 'question':
+                filtered.sort((a, b) => a.question.localeCompare(b.question));
+                break;
+            case 'mostUsed':
+                filtered.sort((a, b) => b.usageCount - a.usageCount);
+                break;
+            default:
+                break;
+        }
+
+        setFilteredAnswers(filtered);
+    };
+
+    const handleAdd = () => {
+        setSelectedAnswer(null);
+        setDialogOpen(true);
+    };
+
+    const handleEdit = (answer: StampAnswer) => {
+        setSelectedAnswer(answer);
+        setDialogOpen(true);
+    };
+
+    const handleToggleActive = (answer: StampAnswer) => {
+        setDeleteTarget(answer);
+        setDeleteDialogOpen(true);
+    };
+
+    const confirmToggleActive = async () => {
+        if (!deleteTarget) return;
+        try {
+            await stampAnswerApi.update(deleteTarget.id, {
+                isActive: !deleteTarget.isActive,
+            });
+            setDeleteDialogOpen(false);
+            setDeleteTarget(null);
+            await loadStampAnswers();
+        } catch (err) {
+            setError('Viga valmisvastuse salvestamisel');
+            console.error('Error toggling stamp answer active state:', err);
+        }
+    };
+
+    const handleDialogClose = (reload?: boolean) => {
+        setDialogOpen(false);
+        setSelectedAnswer(null);
+        if (reload) {
+            loadStampAnswers();
+        }
+    };
+
+    const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchTerm(event.target.value);
+    };
+
+    const handleFilterChange = (event: SelectChangeEvent) => {
+        setFilterActive(event.target.value);
+    };
+
+    const handleSortChange = (event: SelectChangeEvent) => {
+        setSortBy(event.target.value);
+    };
+
+    if (loading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+                <CircularProgress />
+            </Box>
         );
-        break;
-      case "question":
-        filtered.sort((a, b) => a.question.localeCompare(b.question));
-        break;
-      case "mostUsed":
-        filtered.sort((a, b) => b.usageCount - a.usageCount);
-        break;
-      case "priority":
-        filtered.sort((a, b) => b.priority - a.priority);
-        break;
-      default:
-        break;
     }
 
-    setFilteredAnswers(filtered);
-  };
-
-  const handleAdd = () => {
-    setSelectedAnswer(null);
-    setDialogOpen(true);
-  };
-
-  const handleEdit = (answer: StampAnswer) => {
-    setSelectedAnswer(answer);
-    setDialogOpen(true);
-  };
-
-  const handleToggleActive = (answer: StampAnswer) => {
-    setDeleteTarget(answer);
-    setDeleteDialogOpen(true);
-  };
-
-  const confirmToggleActive = async () => {
-    if (!deleteTarget) return;
-    try {
-      await stampAnswerApi.update(deleteTarget.id, {
-        isActive: !deleteTarget.isActive,
-      });
-      setDeleteDialogOpen(false);
-      setDeleteTarget(null);
-      await loadStampAnswers();
-    } catch (err) {
-      setError("Viga valmisvastuse salvestamisel");
-      console.error("Error toggling stamp answer active state:", err);
-    }
-  };
-
-  const handleDialogClose = (reload?: boolean) => {
-    setDialogOpen(false);
-    setSelectedAnswer(null);
-    if (reload) {
-      loadStampAnswers();
-    }
-  };
-
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTerm(event.target.value);
-  };
-
-  const handleFilterChange = (event: SelectChangeEvent) => {
-    setFilterActive(event.target.value);
-  };
-
-  const handleSortChange = (event: SelectChangeEvent) => {
-    setSortBy(event.target.value);
-  };
-
-  if (loading) {
     return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight="400px"
-      >
-        <CircularProgress />
-      </Box>
-    );
-  }
+        <Box>
+            {/* Header */}
+            <Box sx={{ mb: 3 }}>
+                <Typography variant="h4" component="h1" gutterBottom sx={{ color: 'text.primary' }}>
+                    Valmisvastused
+                </Typography>
+                <Typography variant="body1" sx={{ color: 'text.secondary' }}>
+                    Hallake eeldefineeritud küsimusi ja vastuseid
+                </Typography>
+            </Box>
 
-  return (
-    <Box>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          variant="h4"
-          component="h1"
-          gutterBottom
-          sx={{ color: "text.primary" }}
-        >
-          Valmisvastused
-        </Typography>
-        <Typography variant="body1" sx={{ color: "text.secondary" }}>
-          Hallake eeldefineeritud küsimusi ja vastuseid
-        </Typography>
-      </Box>
-
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Add Button */}
-      <Box sx={{ mb: 2 }}>
-        <Button
-          variant="contained"
-          startIcon={<AddIcon />}
-          onClick={handleAdd}
-          sx={{ bgcolor: "primary.main" }}
-        >
-          Lisa uus
-        </Button>
-      </Box>
-
-      {/* Search and Filters */}
-      <Paper sx={{ p: 2, mb: 2, bgcolor: "surface" }}>
-        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-          <TextField
-            placeholder="Otsi..."
-            value={searchTerm}
-            onChange={handleSearchChange}
-            InputProps={{
-              startAdornment: (
-                <SearchIcon sx={{ color: "text.secondary", mr: 1 }} />
-              ),
-            }}
-            sx={{ flex: "1 1 300px" }}
-          />
-
-          <FormControl sx={{ minWidth: 150 }}>
-            <InputLabel>Olek</InputLabel>
-            <Select
-              value={filterActive}
-              onChange={handleFilterChange}
-              label="Olek"
-            >
-              <MenuItem value="all">Kõik</MenuItem>
-              <MenuItem value="active">Aktiivsed</MenuItem>
-              <MenuItem value="inactive">Mitteaktiivsed</MenuItem>
-            </Select>
-          </FormControl>
-
-          <FormControl sx={{ minWidth: 180 }}>
-            <InputLabel>Sorteeri</InputLabel>
-            <Select value={sortBy} onChange={handleSortChange} label="Sorteeri">
-              <MenuItem value="recent">Viimati lisatud</MenuItem>
-              <MenuItem value="question">Küsimus (A-Z)</MenuItem>
-              <MenuItem value="mostUsed">Enim kasutatud</MenuItem>
-              <MenuItem value="priority">Prioriteet</MenuItem>
-            </Select>
-          </FormControl>
-        </Box>
-      </Paper>
-
-      {/* Table */}
-      <TableContainer component={Paper} sx={{ bgcolor: "surface" }}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ color: "text.secondary", fontWeight: "bold" }}>
-                Küsimus
-              </TableCell>
-              <TableCell sx={{ color: "text.secondary", fontWeight: "bold" }}>
-                Vastus
-              </TableCell>
-              <TableCell
-                sx={{ color: "text.secondary", fontWeight: "bold" }}
-                align="center"
-              >
-                Olek
-              </TableCell>
-              <TableCell
-                sx={{ color: "text.secondary", fontWeight: "bold" }}
-                align="center"
-              >
-                Kasutatud
-              </TableCell>
-              <TableCell
-                sx={{ color: "text.secondary", fontWeight: "bold" }}
-                align="right"
-              >
-                Tegevused
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filteredAnswers.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                  <Typography variant="body1" sx={{ color: "text.secondary" }}>
-                    Valmisvastuseid ei leitud
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            ) : (
-              filteredAnswers.map((answer) => (
-                <TableRow
-                  key={answer.id}
-                  sx={{ "&:hover": { bgcolor: "action.hover" } }}
-                >
-                  <TableCell sx={{ color: "text.primary", maxWidth: 300 }}>
-                    {answer.question}
-                  </TableCell>
-                  <TableCell sx={{ color: "text.primary", maxWidth: 400 }}>
-                    {answer.answer.length > 100
-                      ? `${answer.answer.substring(0, 100)}...`
-                      : answer.answer}
-                  </TableCell>
-                  <TableCell align="center">
-                    <Chip
-                      label={answer.isActive ? "Aktiivne" : "Mitteaktiivne"}
-                      color={answer.isActive ? "success" : "default"}
-                      size="small"
-                    />
-                  </TableCell>
-                  <TableCell align="center" sx={{ color: "text.primary" }}>
-                    {answer.usageCount}
-                  </TableCell>
-                  <TableCell align="right">
-                    <IconButton
-                      onClick={() => handleEdit(answer)}
-                      sx={{ color: "primary.main" }}
-                      title="Muuda"
-                    >
-                      <EditIcon />
-                    </IconButton>
-                    <Button
-                      variant="contained"
-                      size="small"
-                      onClick={() => handleToggleActive(answer)}
-                      sx={{
-                        ml: 1,
-                        bgcolor: answer.isActive
-                          ? "error.main"
-                          : "success.main",
-                        color: "surface",
-                        "&:hover": {
-                          bgcolor: answer.isActive
-                            ? "error.dark"
-                            : "success.dark",
-                        },
-                      }}
-                    >
-                      {answer.isActive ? "Inaktiveeri" : "Aktiveeri"}
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))
+            {error && (
+                <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+                    {error}
+                </Alert>
             )}
-          </TableBody>
-        </Table>
-      </TableContainer>
 
-      {/* Dialog */}
-      <StampAnswerDialog
-        open={dialogOpen}
-        answer={selectedAnswer}
-        onClose={handleDialogClose}
-      />
-      <DeleteConfirmationDialog
-        open={deleteDialogOpen}
-        title={
-          deleteTarget
-            ? deleteTarget.isActive
-              ? "Inaktiveeri valmisvastus"
-              : "Aktiveeri valmisvastus"
-            : "Muuda valmisvastuse olekut"
-        }
-        description={
-          deleteTarget
-            ? deleteTarget.isActive
-              ? `Inaktiveeri valmisvastus: "${deleteTarget.question}"? Inaktiveerimisel ei kasutata chatbotis antud küsimuse vastuseks: "${deleteTarget.answer}". Toiming on võimalik tagasi võtta, kui valmisvastus uuesti aktiveerida.`
-              : `Aktiveeri valmisvastus: "${deleteTarget.question}"? Aktiveerimisel kasutatakse valmisvastust chatbotis küsimustele vastamiseks.`
-            : undefined
-        }
-        confirmText={
-          deleteTarget
-            ? deleteTarget.isActive
-              ? "Inaktiveeri"
-              : "Aktiveeri"
-            : "Kinnita"
-        }
-        confirmColor={
-          deleteTarget
-            ? deleteTarget.isActive
-              ? "error"
-              : "success"
-            : "primary"
-        }
-        onConfirm={confirmToggleActive}
-        onClose={() => {
-          setDeleteDialogOpen(false);
-          setDeleteTarget(null);
-        }}
-      />
-    </Box>
-  );
+            {/* Add Button */}
+            <Box sx={{ mb: 2 }}>
+                <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={handleAdd}
+                    sx={{ bgcolor: 'primary.main' }}
+                >
+                    Lisa uus
+                </Button>
+            </Box>
+
+            {/* Search and Filters */}
+            <Paper sx={{ p: 2, mb: 2, bgcolor: 'surface' }}>
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                    <TextField
+                        placeholder="Otsi..."
+                        value={searchTerm}
+                        onChange={handleSearchChange}
+                        InputProps={{
+                            startAdornment: <SearchIcon sx={{ color: 'text.secondary', mr: 1 }} />,
+                        }}
+                        sx={{ flex: '1 1 300px' }}
+                    />
+
+                    <FormControl sx={{ minWidth: 150 }}>
+                        <InputLabel>Olek</InputLabel>
+                        <Select value={filterActive} onChange={handleFilterChange} label="Olek">
+                            <MenuItem value="all">Kõik</MenuItem>
+                            <MenuItem value="active">Aktiivsed</MenuItem>
+                            <MenuItem value="inactive">Mitteaktiivsed</MenuItem>
+                        </Select>
+                    </FormControl>
+
+                    <FormControl sx={{ minWidth: 180 }}>
+                        <InputLabel>Sorteeri</InputLabel>
+                        <Select value={sortBy} onChange={handleSortChange} label="Sorteeri">
+                            <MenuItem value="recent">Viimati lisatud</MenuItem>
+                            <MenuItem value="question">Küsimus (A-Z)</MenuItem>
+                            <MenuItem value="mostUsed">Enim kasutatud</MenuItem>
+                        </Select>
+                    </FormControl>
+                </Box>
+            </Paper>
+
+            {/* Table */}
+            <TableContainer component={Paper} sx={{ bgcolor: 'surface' }}>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell sx={{ color: 'text.secondary', fontWeight: 'bold' }}>Küsimus</TableCell>
+                            <TableCell sx={{ color: 'text.secondary', fontWeight: 'bold' }}>Vastus</TableCell>
+                            <TableCell sx={{ color: 'text.secondary', fontWeight: 'bold' }} align="center">
+                                Olek
+                            </TableCell>
+                            <TableCell sx={{ color: 'text.secondary', fontWeight: 'bold' }} align="center">
+                                Kasutatud
+                            </TableCell>
+                            <TableCell sx={{ color: 'text.secondary', fontWeight: 'bold' }} align="right">
+                                Tegevused
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {filteredAnswers.length === 0 ? (
+                            <TableRow>
+                                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                                    <Typography variant="body1" sx={{ color: 'text.secondary' }}>
+                                        Valmisvastuseid ei leitud
+                                    </Typography>
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            filteredAnswers.map((answer) => (
+                                <TableRow key={answer.id} sx={{ '&:hover': { bgcolor: 'action.hover' } }}>
+                                    <TableCell sx={{ color: 'text.primary', maxWidth: 300 }}>
+                                        {answer.question}
+                                    </TableCell>
+                                    <TableCell sx={{ color: 'text.primary', maxWidth: 400 }}>
+                                        {answer.answer.length > 100
+                                            ? `${answer.answer.substring(0, 100)}...`
+                                            : answer.answer}
+                                    </TableCell>
+                                    <TableCell align="center">
+                                        <Chip
+                                            label={answer.isActive ? 'Aktiivne' : 'Mitteaktiivne'}
+                                            color={answer.isActive ? 'success' : 'default'}
+                                            size="small"
+                                        />
+                                    </TableCell>
+                                    <TableCell align="center" sx={{ color: 'text.primary' }}>
+                                        {answer.usageCount}
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        <IconButton
+                                            onClick={() => handleEdit(answer)}
+                                            sx={{ color: 'primary.main' }}
+                                            title="Muuda"
+                                        >
+                                            <EditIcon />
+                                        </IconButton>
+                                        <Button
+                                            variant="contained"
+                                            size="small"
+                                            onClick={() => handleToggleActive(answer)}
+                                            sx={{
+                                                ml: 1,
+                                                bgcolor: answer.isActive ? 'error.main' : 'success.main',
+                                                color: 'surface',
+                                                '&:hover': {
+                                                    bgcolor: answer.isActive ? 'error.dark' : 'success.dark',
+                                                },
+                                            }}
+                                        >
+                                            {answer.isActive ? 'Inaktiveeri' : 'Aktiveeri'}
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        )}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
+            {/* Dialog */}
+            <StampAnswerDialog open={dialogOpen} answer={selectedAnswer} onClose={handleDialogClose} />
+            <DeleteConfirmationDialog
+                open={deleteDialogOpen}
+                title={
+                    deleteTarget
+                        ? deleteTarget.isActive
+                            ? 'Inaktiveeri valmisvastus'
+                            : 'Aktiveeri valmisvastus'
+                        : 'Muuda valmisvastuse olekut'
+                }
+                description={
+                    deleteTarget
+                        ? deleteTarget.isActive
+                            ? `Inaktiveeri valmisvastus: "${deleteTarget.question}"? Inaktiveerimisel ei kasutata chatbotis antud küsimuse vastuseks: "${deleteTarget.answer}". Toiming on võimalik tagasi võtta, kui valmisvastus uuesti aktiveerida.`
+                            : `Aktiveeri valmisvastus: "${deleteTarget.question}"? Aktiveerimisel kasutatakse valmisvastust chatbotis küsimustele vastamiseks.`
+                        : undefined
+                }
+                confirmText={deleteTarget ? (deleteTarget.isActive ? 'Inaktiveeri' : 'Aktiveeri') : 'Kinnita'}
+                confirmColor={deleteTarget ? (deleteTarget.isActive ? 'error' : 'success') : 'primary'}
+                onConfirm={confirmToggleActive}
+                onClose={() => {
+                    setDeleteDialogOpen(false);
+                    setDeleteTarget(null);
+                }}
+            />
+        </Box>
+    );
 }

--- a/src/features/admin/types/stampAnswer.types.ts
+++ b/src/features/admin/types/stampAnswer.types.ts
@@ -3,8 +3,6 @@ export interface StampAnswer {
   question: string;
   keywords: string | null;
   answer: string;
-  category: string | null;
-  priority: number;
   isActive: boolean;
   usageCount: number;
   lastUsedAt: string | null;
@@ -18,8 +16,6 @@ export interface CreateStampAnswerRequest {
   question: string;
   keywords?: string;
   answer: string;
-  category?: string;
-  priority?: number;
   isActive?: boolean;
 }
 
@@ -27,7 +23,5 @@ export interface UpdateStampAnswerRequest {
   question?: string;
   keywords?: string;
   answer?: string;
-  category?: string;
-  priority?: number;
   isActive?: boolean;
 }


### PR DESCRIPTION
Remove category and priority fields from stamp answer admin interface to match backend changes. These fields were not used in the chat flow and have been deprecated.

Changes:
- Remove category and priority from TypeScript interfaces
- Remove form inputs from StampAnswerDialog
- Remove "Prioriteet" sort option from StampAnswersPage
- Remove getByCategory API method

Related to https://github.com/taltech-vanemarendajaks/team12-chatbot-api/issues/55