### PR TITLE
Fix WebSocket URL for production

### DIFF
--- a/src/features/chat/hooks/useChatWebSocket.ts
+++ b/src/features/chat/hooks/useChatWebSocket.ts
@@ -10,9 +10,8 @@ import type {
 const MAX_RECONNECT_DELAY = 30_000;
 
 function getWsUrl(): string {
-    const baseUrl = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
-
-    return baseUrl.replace(/^http/, "ws") + "/ws/chat";
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return `${protocol}//${window.location.host}/api/ws/chat`;
 }
 
 function tagLastUserMessage(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,5 +14,15 @@ export default defineConfig({
   optimizeDeps: {
     include: ['react', 'react-dom', 'react-router-dom'],
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+        ws: true,
+      },
+    },
+  },
+
 
 })


### PR DESCRIPTION
Previously the frontend attempted to connect to ws://localhost:8080/ws/chat,
which only works in local development.

Updated WebSocket URL to use window.location so it works correctly behind Nginx:

- Uses current host instead of localhost
- Routes through /api/ws/chat

Also added Vite dev proxy configuration so the same WebSocket path works in local development and production.