### PR TITLE
Add comment and empty value for API base URL

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=http://localhost:8080
+# API base URL (leave empty to use same-origin /api proxy)
+VITE_API_BASE_URL=


### PR DESCRIPTION
The value should be left empty to use same-origin /api proxy.