### PR TITLE
Add Grafana metrics integration to admin panel

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,17 @@
+# Production Environment Variables for Frontend
+# Copy this file to .env.production and update with your actual domains
+# These values are embedded at BUILD TIME by Vite
+
+# Backend API URL
+VITE_API_BASE_URL=https://api.yourdomain.com
+
+# Grafana metrics dashboard URL (replace with your production domain)
+# Option 1: Subdomain approach (recommended)
+VITE_GRAFANA_URL=https://metrics.yourdomain.com
+
+# Option 2: Same domain with path (if using reverse proxy)
+# VITE_GRAFANA_URL=https://yourdomain.com/grafana
+
+# Build the production frontend with:
+# npm run build
+# This will use .env.production automatically and create optimized build in dist/

--- a/.env_example
+++ b/.env_example
@@ -1,3 +1,12 @@
 # API base URL (leave empty to use same-origin /api proxy, use http://localhost:8080 base url for auth)
+
 VITE_API_BASE_URL=
 VITE_AUTH_BASE_URL=http://localhost:8080
+
+# Grafana metrics dashboard URL (local development)
+
+VITE_GRAFANA_URL=http://localhost:3000
+
+# For production, copy .env.production.example to .env.production
+
+# and update with your production domains

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # Environment variables
 .env
+.env.production
+.env.local
+.env.*.local

--- a/src/features/admin/layout/AdminLayout.tsx
+++ b/src/features/admin/layout/AdminLayout.tsx
@@ -20,6 +20,7 @@ import {
   Block as BlockIcon,
   Description as DescriptionIcon,
   People as PeopleIcon,
+  BarChart as BarChartIcon,
 } from "@mui/icons-material";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import bossbotLogo from "../../../assets/images/bossbot.svg";
@@ -67,6 +68,12 @@ const menuItems: MenuItem[] = [
     path: "/admin/users",
     enabled: true,
   },
+  {
+    text: "Mõõdikud",
+    icon: <BarChartIcon />,
+    path: "/admin/metrics",
+    enabled: true,
+  },
 ];
 
 export default function AdminLayout() {
@@ -101,10 +108,19 @@ export default function AdminLayout() {
   };
 
   const handleNavigation = (path: string, enabled: boolean) => {
-    if (enabled) {
-      navigate(path);
-      setDrawerOpen(false); // Close drawer after navigation
+    if (!enabled) return;
+    
+    // Special handling for metrics - open Grafana in new tab
+    if (path === "/admin/metrics") {
+      const grafanaUrl = import.meta.env.VITE_GRAFANA_URL || "http://localhost:3000";
+      window.open(grafanaUrl, "_blank", "noopener,noreferrer");
+      setDrawerOpen(false);
+      return;
     }
+    
+    // Normal navigation for other routes
+    navigate(path);
+    setDrawerOpen(false);
   };
 
   const handleAuthAction = () => {


### PR DESCRIPTION
Add "Mõõdikud" menu item in admin drawer that opens Grafana dashboard in a new tab:

- Add metrics menu item with BarChart icon as last drawer element
- Implement special navigation handler to open Grafana in new tab
- Add VITE_GRAFANA_URL environment variable support
- Create .env.production.example with production URL template
- Update .env_example with local development defaults
- Update .gitignore to exclude .env.production files

<img width="544" height="571" alt="Screenshot 2026-04-19 at 21 43 38" src="https://github.com/user-attachments/assets/57334e6a-9691-4bce-84d4-c4b66a9d4397" />

Related to https://github.com/taltech-vanemarendajaks/team12-chatbot-api/issues/53