### PR TITLE
Update OAuth login flow and add Vite proxy for local dev

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -52,9 +52,7 @@ export async function fetchLocalDevSecurityStatus(): Promise<LocalDevSecurity> {
     }
 }
 
-export function getLoginPage() {
-    const baseUrl = import.meta.env.VITE_AUTH_BASE_URL;
-    const login = authEndpoints.getLogin;
-
-    return `${baseUrl}${login}`;
+export function getLoginPage(): string {
+    return authEndpoints.getLogin;
 }
+

--- a/src/features/auth/api/endpoints.ts
+++ b/src/features/auth/api/endpoints.ts
@@ -1,6 +1,6 @@
 export const authEndpoints = {
     getCurrentUser: '/api/v1/account',
     getLogout: '/auth/logout',
-    getLogin: '/auth/login',
+    getLogin: '/oauth2/authorization/google',
     getLocalDevSecurityStatus: '/api/v1/security-status',
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,14 @@ export default defineConfig({
         changeOrigin: true,
         ws: true,
       },
+      "/oauth2": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+      "/login": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
     },
   },
 


### PR DESCRIPTION
1. Login endpoint updated

/auth/login → /oauth2/authorization/google

Frontend now calls Spring Security’s built-in OAuth2 endpoint directly.

2. Removed manual base URL construction

Removed usage of VITE_AUTH_BASE_URL in getLoginPage()

3. Added Vite proxy for local development

Added proxy routes for:
- /oauth2
- /login

Why?

Because backend authentication flow was refactored:

Previously:
- Frontend called /auth/login
- Backend manually handled OAuth redirect and token flow

Now:
- Spring Security handles OAuth flow internally
- /oauth2/authorization/google starts the login process

This change was necessary because:
- Default Spring OAuth flow cannot be correctly triggered via the old custom endpoint
- JWT cookie is now issued in a custom success handler in backend
- Frontend must initiate login using the correct Spring Security endpoint

Why Vite proxy was added

OAuth endpoints (/oauth2, /login) are not under /api

Without proxy:
- Requests stay in frontend dev server
- OAuth flow breaks locally

Proxy ensures:
- Local dev behaves like production
- Requests reach backend correctly
